### PR TITLE
Fix cyclic references using WeakReference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
   "autoload": {
     "psr-4": {
       "Bdf\\Form\\": "src"
-    }
+    },
+    "classmap": ["polyfill/WeakReference.php"]
   },
   "autoload-dev": {
     "psr-4": {

--- a/polyfill/WeakReference.php
+++ b/polyfill/WeakReference.php
@@ -1,0 +1,50 @@
+<?php
+
+if (!class_exists(WeakReference::class)) {
+    /**
+     * Pseudo polyfill for get the WeakReference API on PHP < 7.4
+     *
+     * https://www.php.net/manual/en/class.weakreference.php
+     *
+     * @template T as object
+     */
+    class WeakReference
+    {
+        /**
+         * @var T
+         */
+        private $obj;
+
+        /**
+         * WeakReference constructor.
+         *
+         * @param T $obj
+         */
+        private function __construct($obj)
+        {
+            $this->obj = $obj;
+        }
+
+        /**
+         * Get a weakly referenced Object
+         *
+         * @return T|null
+         */
+        public function get()
+        {
+            return $this->obj;
+        }
+
+        /**
+         * Create a new weak reference
+         *
+         * @param T $obj
+         *
+         * @return WeakReference
+         */
+        public static function create($obj): WeakReference
+        {
+            return new self($obj);
+        }
+    }
+}

--- a/src/Aggregate/ArrayElement.php
+++ b/src/Aggregate/ArrayElement.php
@@ -306,8 +306,8 @@ final class ArrayElement implements ChildAggregateInterface, Countable, Choiceab
      */
     public function root(): RootElementInterface
     {
-        if ($this->container) {
-            return $this->container->parent()->root();
+        if ($container = $this->container()) {
+            return $container->parent()->root();
         }
 
         // @todo Use root form ?

--- a/src/Aggregate/Form.php
+++ b/src/Aggregate/Form.php
@@ -223,8 +223,8 @@ final class Form implements FormInterface
      */
     public function root(): RootElementInterface
     {
-        if ($this->container) {
-            return $this->container->parent()->root();
+        if ($container = $this->container()) {
+            return $container->parent()->root();
         }
 
         if ($this->root) {

--- a/src/Aggregate/RootForm.php
+++ b/src/Aggregate/RootForm.php
@@ -15,6 +15,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\ValidatorBuilder;
+use WeakReference;
 
 /**
  * Adapt a form element as root element
@@ -49,7 +50,7 @@ use Symfony\Component\Validator\ValidatorBuilder;
 final class RootForm implements RootElementInterface, ChildAggregateInterface
 {
     /**
-     * @var Form
+     * @var WeakReference<Form>
      */
     private $form;
 
@@ -84,7 +85,7 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
      */
     public function __construct(Form $form, array $buttons = [], ?PropertyAccessorInterface $propertyAccessor = null, ?ValidatorInterface $validator = null)
     {
-        $this->form = $form;
+        $this->form = WeakReference::create($form);
         $this->buttons = $buttons;
         $this->propertyAccessor = $propertyAccessor;
         $this->validator = $validator;
@@ -96,7 +97,8 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
     public function submit($data): ElementInterface
     {
         $this->submitToButtons($data);
-        $this->form->submit($data);
+        /** @psalm-suppress PossiblyNullReference */
+        $this->form->get()->submit($data);
 
         return $this;
     }
@@ -107,7 +109,8 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
     public function patch($data): ElementInterface
     {
         $this->submitToButtons($data);
-        $this->form->patch($data);
+        /** @psalm-suppress PossiblyNullReference */
+        $this->form->get()->patch($data);
 
         return $this;
     }
@@ -117,7 +120,8 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
      */
     public function import($entity): ElementInterface
     {
-        $this->form->import($entity);
+        /** @psalm-suppress PossiblyNullReference */
+        $this->form->get()->import($entity);
 
         return $this;
     }
@@ -127,7 +131,8 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
      */
     public function value()
     {
-        return $this->form->value();
+        /** @psalm-suppress PossiblyNullReference */
+        return $this->form->get()->value();
     }
 
     /**
@@ -135,7 +140,8 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
      */
     public function httpValue()
     {
-        $httpValue = $this->form->httpValue();
+        /** @psalm-suppress PossiblyNullReference */
+        $httpValue = $this->form->get()->httpValue();
 
         if (empty($this->buttons)) {
             return $httpValue;
@@ -155,7 +161,8 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
      */
     public function valid(): bool
     {
-        return $this->form->valid();
+        /** @psalm-suppress PossiblyNullReference */
+        return $this->form->get()->valid();
     }
 
     /**
@@ -163,7 +170,8 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
      */
     public function error(?HttpFieldPath $field = null): FormError
     {
-        return $this->form->error($field);
+        /** @psalm-suppress PossiblyNullReference */
+        return $this->form->get()->error($field);
     }
 
     /**
@@ -201,7 +209,8 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
             $buttons[$button->name()] = $button->view($field);
         }
 
-        $view = $this->form->view($field);
+        /** @psalm-suppress PossiblyNullReference */
+        $view = $this->form->get()->view($field);
         $view->setButtons($buttons);
 
         return $view;
@@ -253,10 +262,15 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-suppress InvalidNullableReturnType
+     * @psalm-suppress PossiblyNullReference
+     * @psalm-suppress PossiblyNullArrayAccess
+     * @psalm-suppress NullableReturnStatement
      */
     public function offsetGet($offset): ChildInterface
     {
-        return $this->form[$offset];
+        return $this->form->get()[$offset];
     }
 
     /**
@@ -264,7 +278,8 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
      */
     public function offsetExists($offset): bool
     {
-        return isset($this->form[$offset]);
+        /** @psalm-suppress PossiblyNullReference */
+        return isset($this->form->get()[$offset]);
     }
 
     /**
@@ -272,15 +287,19 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
      */
     public function offsetSet($offset, $value)
     {
-        $this->form[$offset] = $value;
+        /** @psalm-suppress PossiblyNullReference */
+        $this->form->get()[$offset] = $value;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-suppress PossiblyNullReference
+     * @psalm-suppress PossiblyNullArrayAccess
      */
     public function offsetUnset($offset)
     {
-        unset($this->form[$offset]);
+        unset($this->form->get()[$offset]);
     }
 
     /**
@@ -288,7 +307,8 @@ final class RootForm implements RootElementInterface, ChildAggregateInterface
      */
     public function getIterator()
     {
-        return $this->form->getIterator();
+        /** @psalm-suppress PossiblyNullReference */
+        return $this->form->get()->getIterator();
     }
 
     /**

--- a/src/Constraint/ClosureValidator.php
+++ b/src/Constraint/ClosureValidator.php
@@ -5,6 +5,7 @@ namespace Bdf\Form\Constraint;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use WeakReference;
 
 /**
  * Validator for @see Closure
@@ -20,7 +21,9 @@ class ClosureValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Closure::class);
         }
 
-        $error = ($constraint->callback)($value, $this->context->getRoot(), $this->context);
+        $element = $this->context->getRoot() instanceof WeakReference ? $this->context->getRoot()->get() : null;
+        /** @psalm-suppress PossiblyNullArgument */
+        $error = ($constraint->callback)($value, $element, $this->context);
         $code = null;
 
         if ($error === true) {

--- a/src/Constraint/FieldComparisonValidatorTrait.php
+++ b/src/Constraint/FieldComparisonValidatorTrait.php
@@ -24,7 +24,7 @@ trait FieldComparisonValidatorTrait
     {
         /** @var FieldComparisonTrait $constraint */
         /** @var ElementInterface $element */
-        $element = $this->context->getRoot();
+        $element = $this->context->getRoot()->get();
         $field = $constraint->field;
 
         if (!$field instanceof FieldPath) {

--- a/src/Csrf/CsrfConstraint.php
+++ b/src/Csrf/CsrfConstraint.php
@@ -12,7 +12,6 @@ class CsrfConstraint extends Constraint
 {
     const INVALID_TOKEN_ERROR = 'cd108896-d12a-4455-a6cc-ba13708c8e7f';
 
-    /** @var array<string, string> */
     protected static $errorNames = [
         self::INVALID_TOKEN_ERROR => 'INVALID_TOKEN_ERROR',
     ];

--- a/src/Csrf/CsrfElement.php
+++ b/src/Csrf/CsrfElement.php
@@ -143,7 +143,7 @@ final class CsrfElement implements ElementInterface
      */
     public function root(): RootElementInterface
     {
-        return $this->container() ? $this->container()->parent()->root() : new LeafRootElement($this);
+        return ($container = $this->container()) ? $container->parent()->root() : new LeafRootElement($this);
     }
 
     /**

--- a/src/Leaf/LeafElement.php
+++ b/src/Leaf/LeafElement.php
@@ -173,12 +173,12 @@ abstract class LeafElement implements ElementInterface, Choiceable
      */
     final public function root(): RootElementInterface
     {
-        // @todo save the root ?
-        if (!$this->container) {
-            return new LeafRootElement($this);
+        if ($container = $this->container()) {
+            return $container->parent()->root();
         }
 
-        return $this->container->parent()->root();
+        // @todo save the root ?
+        return new LeafRootElement($this);
     }
 
     /**

--- a/src/Phone/ValidPhoneNumber.php
+++ b/src/Phone/ValidPhoneNumber.php
@@ -11,7 +11,6 @@ class ValidPhoneNumber extends Constraint
 {
     const INVALID_PHONE_NUMBER_ERROR = '5169f03c-ec96-4e62-8651-9ee6766e0b5a';
 
-    /** @var array<string, string> */
     protected static $errorNames = [
         self::INVALID_PHONE_NUMBER_ERROR => 'INVALID_PHONE_NUMBER_ERROR',
     ];

--- a/src/PropertyAccess/AbstractAccessor.php
+++ b/src/PropertyAccess/AbstractAccessor.php
@@ -31,7 +31,7 @@ abstract class AbstractAccessor implements AccessorInterface
     protected $propertyAccessor;
 
     /**
-     * @var ChildInterface
+     * @var ChildInterface|null
      */
     protected $input;
 
@@ -67,7 +67,7 @@ abstract class AbstractAccessor implements AccessorInterface
     /**
      * {@inheritdoc}
      */
-    final public function setFormElement(ChildInterface $formElement): void
+    final public function setFormElement(?ChildInterface $formElement): void
     {
         $this->input = $formElement;
     }
@@ -102,10 +102,10 @@ abstract class AbstractAccessor implements AccessorInterface
      */
     final protected function getPropertyName()
     {
-        if ($this->propertyName === null) {
+        if ($this->propertyName === null && $this->input) {
             $this->propertyName = $this->input->name();
         }
 
-        return $this->propertyName;
+        return (string) $this->propertyName;
     }
 }

--- a/src/PropertyAccess/AccessorInterface.php
+++ b/src/PropertyAccess/AccessorInterface.php
@@ -20,7 +20,7 @@ interface AccessorInterface
     /**
      * Set form element
      * 
-     * @param ChildInterface $formElement
+     * @param ChildInterface|null $formElement
      */
-    public function setFormElement(ChildInterface $formElement): void;
+    public function setFormElement(?ChildInterface $formElement): void;
 }

--- a/src/Util/ContainerTrait.php
+++ b/src/Util/ContainerTrait.php
@@ -4,6 +4,7 @@ namespace Bdf\Form\Util;
 
 use Bdf\Form\Child\ChildInterface;
 use Bdf\Form\ElementInterface;
+use WeakReference;
 
 /**
  * Implements get and set container methods for an element
@@ -11,7 +12,7 @@ use Bdf\Form\ElementInterface;
 trait ContainerTrait
 {
     /**
-     * @var ChildInterface|null
+     * @var WeakReference<ChildInterface>|null
      */
     private $container;
 
@@ -21,7 +22,7 @@ trait ContainerTrait
      */
     final public function container(): ?ChildInterface
     {
-        return $this->container;
+        return $this->container ? $this->container->get() : null;
     }
 
     /**
@@ -33,7 +34,7 @@ trait ContainerTrait
     final public function setContainer(ChildInterface $container): ElementInterface
     {
         $element = clone $this;
-        $element->container = $container;
+        $element->container = WeakReference::create($container);
 
         return $element;
     }

--- a/src/Validator/ConstraintValueValidator.php
+++ b/src/Validator/ConstraintValueValidator.php
@@ -57,7 +57,8 @@ final class ConstraintValueValidator implements ValueValidatorInterface
         $groups = $root->constraintGroups();
 
         /** @psalm-suppress TooManyArguments */
-        $context = $root->getValidator()->startContext($element);
+        // Note: Wrapping the element into a WeakReference will cause a BC break
+        $context = $root->getValidator()->startContext(\WeakReference::create($element));
 
         foreach ($this->constraints as $constraint) {
             $errors = $context->validate($value, $constraint, $groups)->getViolations();

--- a/src/Validator/TransformerExceptionConstraint.php
+++ b/src/Validator/TransformerExceptionConstraint.php
@@ -12,7 +12,6 @@ final class TransformerExceptionConstraint extends Constraint
 {
     const TRANSFORM_ERROR = 'b5acab45-80b0-4808-8784-6577e37ac869';
 
-    /** @var array<string, string> */
     protected static $errorNames = [
         self::TRANSFORM_ERROR => 'TRANSFORM_ERROR',
     ];

--- a/tests/Aggregate/ArrayElementTest.php
+++ b/tests/Aggregate/ArrayElementTest.php
@@ -383,7 +383,7 @@ class ArrayElementTest extends TestCase
     {
         $element = new ArrayElement(new StringElement());
         $parent = new Form(new ChildrenCollection());
-        $element = $element->setContainer(new Child('child', $element));
+        $element = $element->setContainer($container = new Child('child', $element));
         $element->container()->setParent($parent);
 
         $this->assertSame($parent->root(), $element->root());

--- a/tests/Aggregate/RootFormTest.php
+++ b/tests/Aggregate/RootFormTest.php
@@ -200,7 +200,7 @@ class RootFormTest extends TestCase
      */
     public function test_delegation()
     {
-        $form = new RootForm(new Form(new ChildrenCollection([
+        $form = new RootForm($inner = new Form(new ChildrenCollection([
             new Child('value', new IntegerElement(), new ArrayOffsetHttpFields('value'))
         ])));
 

--- a/tests/Child/ChildBuilderTest.php
+++ b/tests/Child/ChildBuilderTest.php
@@ -62,7 +62,7 @@ class ChildBuilderTest extends TestCase
             ->transformer(function ($value) { return $value.'C'; }, false)
             ->buildChild()
         ;
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit(['child' => 'foo']);
         $this->assertSame('fooBAC', $child->element()->value());
@@ -74,7 +74,7 @@ class ChildBuilderTest extends TestCase
     public function test_required()
     {
         $child = $this->builder->required()->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit([]);
         $this->assertEquals('This value should not be blank.', $child->error()->global());
@@ -86,7 +86,7 @@ class ChildBuilderTest extends TestCase
     public function test_required_with_custom_message()
     {
         $child = $this->builder->required('my message')->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit([]);
         $this->assertEquals('my message', $child->error()->global());
@@ -98,7 +98,7 @@ class ChildBuilderTest extends TestCase
     public function test_required_with_custom_constraint()
     {
         $child = $this->builder->required(new Positive())->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit(['child' => '-1']);
         $this->assertEquals('This value should be positive.', $child->error()->global());
@@ -110,7 +110,7 @@ class ChildBuilderTest extends TestCase
     public function test_hydrator()
     {
         $child = $this->builder->hydrator(new Setter('prop'))->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->element()->import('value');
 
         $target = [];
@@ -125,7 +125,7 @@ class ChildBuilderTest extends TestCase
     public function test_extractor()
     {
         $child = $this->builder->extractor(new Getter('prop'))->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $target = ['prop' => 'value'];
         $child->import($target);
@@ -142,7 +142,7 @@ class ChildBuilderTest extends TestCase
             ->filter(function ($value) { return $value.'a'; })
             ->filter(function ($value) { return $value.'b'; })
             ->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit(['child' => '']);
         $this->assertEquals('ab', $child->element()->value());
@@ -157,7 +157,7 @@ class ChildBuilderTest extends TestCase
             ->filter(function ($value) { return $value.'a'; }, false)
             ->filter(function ($value) { return $value.'b'; }, false)
             ->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit(['child' => '']);
         $this->assertEquals('ba', $child->element()->value());
@@ -169,7 +169,7 @@ class ChildBuilderTest extends TestCase
     public function test_default()
     {
         $child = $this->builder->default('default')->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit([]);
 
@@ -182,7 +182,7 @@ class ChildBuilderTest extends TestCase
     public function test_default_with_value()
     {
         $child = $this->builder->default('default')->value('value')->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertEquals('value', $child->element()->value());
 
@@ -200,7 +200,7 @@ class ChildBuilderTest extends TestCase
             ->buildChild()
         ;
 
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit([]);
 
@@ -224,7 +224,7 @@ class ChildBuilderTest extends TestCase
     public function test_setter()
     {
         $child = $this->builder->setter('prop')->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->element()->import('value');
 
         $target = [];
@@ -239,7 +239,7 @@ class ChildBuilderTest extends TestCase
     public function test_getter()
     {
         $child = $this->builder->getter('prop')->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $target = ['prop' => 'value'];
         $child->import($target);
@@ -296,19 +296,19 @@ class ChildBuilderTest extends TestCase
     public function test_trim()
     {
         $child = $this->builder->trim(true)->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit(['child' => '  a  ']);
         $this->assertEquals('a', $child->element()->value());
 
         $child = $this->builder->trim(false)->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit(['child' => '  a  ']);
         $this->assertEquals('  a  ', $child->element()->value());
 
         $child = $this->builder->trim()->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit(['child' => '  a  ']);
         $this->assertEquals('a', $child->element()->value());
@@ -324,7 +324,7 @@ class ChildBuilderTest extends TestCase
         $child = $this->builder->prefix()->buildChild();
 
         $this->assertInstanceOf(Child::class, $child);
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->submit(['child_0' => 'foo', 'child_1' => 'bar']);
         $this->assertSame(['foo', 'bar'], $child->element()->value());
     }
@@ -338,7 +338,7 @@ class ChildBuilderTest extends TestCase
         $child = $this->builder->prefix('prefix_')->buildChild();
 
         $this->assertInstanceOf(Child::class, $child);
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->submit(['prefix_0' => 'foo', 'prefix_1' => 'bar']);
         $this->assertSame(['foo', 'bar'], $child->element()->value());
     }
@@ -352,7 +352,7 @@ class ChildBuilderTest extends TestCase
         $child = $this->builder->prefix('')->buildChild();
 
         $this->assertInstanceOf(Child::class, $child);
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->submit(['foo', 'bar']);
         $this->assertSame(['foo', 'bar'], $child->element()->value());
     }
@@ -365,7 +365,7 @@ class ChildBuilderTest extends TestCase
         $fields = $this->createMock(HttpFieldsInterface::class);
 
         $child = $this->builder->httpFields($fields)->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $fields->expects($this->once())->method('extract')->with(['foo' => 'bar'])->willReturn('bar');
 
@@ -395,7 +395,7 @@ class ChildBuilderTest extends TestCase
             ->setter('prop')->getter('prop')
             ->buildChild()
         ;
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->element()->import('value');
 
         $target = [];
@@ -454,7 +454,7 @@ class ChildBuilderTest extends TestCase
 
         $builder->test();
         $child = $builder->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit(['child' => '']);
         $this->assertEquals('ABC', $child->element()->value());

--- a/tests/Child/ChildTest.php
+++ b/tests/Child/ChildTest.php
@@ -63,7 +63,7 @@ class ChildTest extends TestCase
     public function test_import_with_array()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], new NotBlank(['message' => 'required error']), null, new Getter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->import(['child' => 'my value']);
         $this->assertSame('my value', $child->element()->value());
@@ -75,7 +75,7 @@ class ChildTest extends TestCase
     public function test_import_with_object()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], new NotBlank(['message' => 'required error']), null, new Getter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->import((object) ['child' => 'my value']);
         $this->assertSame('my value', $child->element()->value());
@@ -89,7 +89,7 @@ class ChildTest extends TestCase
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], new NotBlank(['message' => 'required error']), null, new Getter(), [], new ClosureTransformer(function($value) {
             return base64_encode($value);
         }));
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->import(['child' => 'my value']);
         $this->assertSame(base64_encode('my value'), $child->element()->value());
@@ -101,7 +101,7 @@ class ChildTest extends TestCase
     public function test_fill_with_array()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], new NotBlank(['message' => 'required error']), new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->element()->import('my value');
 
         $target = [];
@@ -116,7 +116,7 @@ class ChildTest extends TestCase
     public function test_fill_with_object()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], new NotBlank(['message' => 'required error']), new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->element()->import('my value');
 
         $target = (object) ['child' => null];
@@ -133,7 +133,7 @@ class ChildTest extends TestCase
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], new NotBlank(['message' => 'required error']), new Setter(), null, [], new ClosureTransformer(function($value) {
             return base64_encode($value);
         }));
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->element()->import('my value');
 
         $target = (object) ['child' => null];
@@ -148,7 +148,7 @@ class ChildTest extends TestCase
     public function test_submit_empty($value)
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit($value));
         $this->assertEmpty($child->element()->value());
@@ -160,7 +160,7 @@ class ChildTest extends TestCase
     public function test_submit_empty_with_default_value($value)
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], 'default', new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit($value));
         $this->assertEquals('default', $child->element()->value());
@@ -172,7 +172,7 @@ class ChildTest extends TestCase
     public function test_submit_empty_with_default_value_on_array_element($value)
     {
         $child = new Child('child', new ArrayElement(new StringElement()), new ArrayOffsetHttpFields('child'), [], ['default'], new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit($value));
         $this->assertEquals(['default'], $child->element()->value());
@@ -184,7 +184,7 @@ class ChildTest extends TestCase
     public function test_submit_not_empty($value)
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit(['child' => $value]));
         $this->assertEquals($value, $child->element()->value());
@@ -196,7 +196,7 @@ class ChildTest extends TestCase
     public function test_submit_element_constraint_error()
     {
         $child = new Child('child', new StringElement(new ConstraintValueValidator([new NotEqualTo('value')])), new ArrayOffsetHttpFields('child'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertFalse($child->submit(['child' => 'value']));
         $this->assertEquals('value', $child->element()->value());
@@ -212,7 +212,7 @@ class ChildTest extends TestCase
     public function test_submit_with_filters()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [new ClosureFilter(function ($value) { return strtoupper($value); }), new ClosureFilter(function ($value) { return substr($value, 0, 3); })]);
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit(['child' => 'hello world !']));
         $this->assertEquals('HEL', $child->element()->value());
@@ -224,7 +224,7 @@ class ChildTest extends TestCase
     public function test_submit_with_filters_which_return_null_should_use_the_default_value()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [new ClosureFilter(function ($value) { return strtoupper($value); }), new ClosureFilter(function () use(&$filterArgs) { $filterArgs = func_get_args(); return null; })], 'bar');
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit(['child' => 'hello world !']));
         $this->assertEquals('bar', $child->element()->value());
@@ -238,7 +238,7 @@ class ChildTest extends TestCase
     public function test_patch_empty()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->element()->import('foo');
 
@@ -264,7 +264,7 @@ class ChildTest extends TestCase
     public function test_patch_null_with_prefix()
     {
         $child = new Child('child', new ArrayElement(new StringElement()), new PrefixedHttpFields('p'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->element()->import(['foo']);
 
@@ -278,7 +278,7 @@ class ChildTest extends TestCase
     public function test_patch_not_empty()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->element()->import('foo');
 
@@ -292,7 +292,7 @@ class ChildTest extends TestCase
     public function test_httpFields()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [new ClosureFilter(function ($value) { return strtoupper($value); }), new ClosureFilter(function ($value) { return substr($value, 0, 3); })]);
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->element()->import('value');
 
         $this->assertSame(['child' => 'value'], $child->httpFields());
@@ -304,7 +304,7 @@ class ChildTest extends TestCase
     public function test_view()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [new ClosureFilter(function ($value) { return strtoupper($value); }), new ClosureFilter(function ($value) { return substr($value, 0, 3); })]);
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->element()->import('value');
 
         $view = $child->view();

--- a/tests/Child/Http/ArrayOffsetHttpFieldsTest.php
+++ b/tests/Child/Http/ArrayOffsetHttpFieldsTest.php
@@ -24,7 +24,7 @@ class ArrayOffsetHttpFieldsTest extends TestCase
     public function test_submit_empty($value)
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit($value));
         $this->assertEmpty($child->element()->value());
@@ -63,7 +63,7 @@ class ArrayOffsetHttpFieldsTest extends TestCase
     public function test_submit_empty_with_default_value($value)
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], 'default', new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit($value));
         $this->assertEquals('default', $child->element()->value());
@@ -75,7 +75,7 @@ class ArrayOffsetHttpFieldsTest extends TestCase
     public function test_submit_not_empty($value)
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit(['child' => $value]));
         $this->assertEquals($value, $child->element()->value());
@@ -87,7 +87,7 @@ class ArrayOffsetHttpFieldsTest extends TestCase
     public function test_submit_element_constraint_error()
     {
         $child = new Child('child', new StringElement(new ConstraintValueValidator([new NotEqualTo('value')])), new ArrayOffsetHttpFields('child'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertFalse($child->submit(['child' => 'value']));
         $this->assertEquals('value', $child->element()->value());
@@ -103,7 +103,7 @@ class ArrayOffsetHttpFieldsTest extends TestCase
     public function test_submit_with_filters()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [new ClosureFilter(function ($value) { return strtoupper($value); }), new ClosureFilter(function ($value) { return substr($value, 0, 3); })]);
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit(['child' => 'hello world !']));
         $this->assertEquals('HEL', $child->element()->value());
@@ -115,7 +115,7 @@ class ArrayOffsetHttpFieldsTest extends TestCase
     public function test_httpFields()
     {
         $child = new Child('child', new StringElement(), new ArrayOffsetHttpFields('child'), [new ClosureFilter(function ($value) { return strtoupper($value); }), new ClosureFilter(function ($value) { return substr($value, 0, 3); })]);
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->element()->import('value');
 
         $this->assertSame(['child' => 'value'], $child->httpFields());

--- a/tests/Child/Http/PrefixedHttpFieldsTest.php
+++ b/tests/Child/Http/PrefixedHttpFieldsTest.php
@@ -25,7 +25,7 @@ class PrefixedHttpFieldsTest extends TestCase
     public function test_submit_empty($value)
     {
         $child = new Child('child', new ArrayElement(new StringElement()), new PrefixedHttpFields('child_'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit($value));
         $this->assertSame([], $child->element()->value());
@@ -37,7 +37,7 @@ class PrefixedHttpFieldsTest extends TestCase
     public function test_submit_empty_with_default_value($value)
     {
         $child = new Child('child', new ArrayElement(new StringElement()), new PrefixedHttpFields('child_'), [], ['default'], new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit($value));
         $this->assertEquals(['default'], $child->element()->value());
@@ -57,7 +57,7 @@ class PrefixedHttpFieldsTest extends TestCase
     public function test_submit_not_empty()
     {
         $child = new Child('child', new ArrayElement(new StringElement()), new PrefixedHttpFields('child_'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit(['child_0' => 'foo', 'child_bar' => 'baz', 'other' => 42]));
         $this->assertSame([0 => 'foo', 'bar' => 'baz'], $child->element()->value());
@@ -69,7 +69,7 @@ class PrefixedHttpFieldsTest extends TestCase
     public function test_submit_not_empty_with_default()
     {
         $child = new Child('child', new ArrayElement(new StringElement()), new PrefixedHttpFields('child_'), [], ['default'], new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit(['child_0' => 'foo', 'child_bar' => 'baz', 'other' => 42]));
         $this->assertSame([0 => 'foo', 'bar' => 'baz'], $child->element()->value());
@@ -81,7 +81,7 @@ class PrefixedHttpFieldsTest extends TestCase
     public function test_submit_element_constraint_error()
     {
         $child = new Child('child', new ArrayElement(new StringElement(), null, new ConstraintValueValidator([new Count(['min' => 2])])), new PrefixedHttpFields('child_'), [], null, new Setter());
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertFalse($child->submit(['child_0' => 'value']));
         $this->assertEquals(['value'], $child->element()->value());
@@ -97,7 +97,7 @@ class PrefixedHttpFieldsTest extends TestCase
     public function test_submit_with_filters()
     {
         $child = new Child('child', new ArrayElement(new StringElement()), new PrefixedHttpFields('child_'), [new ClosureFilter(function ($value) { return array_change_key_case($value, CASE_UPPER); })]);
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $this->assertTrue($child->submit(['child_message' => 'hello world !']));
         $this->assertEquals(['MESSAGE' => 'hello world !'], $child->element()->value());
@@ -109,7 +109,7 @@ class PrefixedHttpFieldsTest extends TestCase
     public function test_httpFields()
     {
         $child = new Child('child', new ArrayElement(new StringElement()), new PrefixedHttpFields('child_'));
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->element()->import(['value', 'foo' => 'bar']);
 
         $this->assertSame(['child_0' => 'value', 'child_foo' => 'bar'], $child->httpFields());

--- a/tests/Csrf/CsrfElementTest.php
+++ b/tests/Csrf/CsrfElementTest.php
@@ -159,7 +159,7 @@ class CsrfElementTest extends TestCase
         $this->assertNull($element->container());
 
         $container = new Child('name', $element);
-        $container->setParent(new Form(new ChildrenCollection()));
+        $container->setParent($form = new Form(new ChildrenCollection()));
 
         $element = $element->setContainer($container);
 

--- a/tests/CyclicReferenceTest.php
+++ b/tests/CyclicReferenceTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Bdf\Form;
+
+use Bdf\Form\Aggregate\FormBuilderInterface;
+use Bdf\Form\Child\ChildBuilderInterface;
+use Bdf\Form\Custom\CustomForm;
+use PHPUnit\Framework\TestCase;
+use WeakReference;
+
+/**
+ * Class CyclicReferenceTest
+ *
+ * @requires PHP 7.4
+ */
+class CyclicReferenceTest extends TestCase
+{
+    /**
+     *
+     */
+    public function test_simple()
+    {
+        $form = new MyCustomForm();
+
+        $this->assertSame(1, MyCustomForm::$count);
+
+        unset($form);
+        $this->assertSame(0, MyCustomForm::$count);
+    }
+
+    /**
+     *
+     */
+    public function test_children_should_be_destroyed()
+    {
+        $form = new MyCustomForm();
+        $form->submit([
+            'foo' => 'foo',
+            'bar' => 42,
+            'embedded' => [
+                'foo' => 'foo2'
+            ]
+        ]);
+        $form->value();
+
+        $foo = WeakReference::create($form['foo']);
+        $fooElement = WeakReference::create($form['foo']->element());
+        $bar = WeakReference::create($form['bar']);
+        $barElement = WeakReference::create($form['bar']->element());
+        $embedded = WeakReference::create($form['embedded']);
+        $embeddedElement = WeakReference::create($form['embedded']->element());
+        $embeddedFoo = WeakReference::create($form['embedded']->element()['foo']);
+        $embeddedFooElement = WeakReference::create($form['embedded']->element()['foo']->element());
+
+        unset($form);
+
+        $this->assertNull($foo->get());
+        $this->assertNull($fooElement->get());
+        $this->assertNull($bar->get());
+        $this->assertNull($barElement->get());
+        $this->assertNull($embedded->get());
+        $this->assertNull($embeddedElement->get());
+        $this->assertNull($embeddedFoo->get());
+        $this->assertNull($embeddedFooElement->get());
+    }
+
+    /**
+     *
+     */
+    public function test_generate_value()
+    {
+        $form = new MyCustomForm();
+        $form->submit([
+            'foo' => 'foo',
+            'bar' => 42,
+            'embedded' => [
+                'foo' => 'foo2'
+            ]
+        ]);
+
+        $entity = $form->value();
+
+        $this->assertSame(1, MyCustomForm::$count);
+        $this->assertSame(2, MyCustomEntity::$count);
+
+        unset($form, $entity);
+        $this->assertSame(0, MyCustomForm::$count);
+        $this->assertSame(0, MyCustomEntity::$count);
+    }
+
+    /**
+     *
+     */
+    public function test_import()
+    {
+        $form = new MyCustomForm();
+        $form->import($entity = new MyCustomEntity());
+
+        $this->assertSame(1, MyCustomForm::$count);
+        $this->assertSame(1, MyCustomEntity::$count);
+
+        $this->assertSame($entity, $form->value());
+
+        unset($form);
+        $this->assertSame(0, MyCustomForm::$count);
+        $this->assertSame(1, MyCustomEntity::$count);
+
+        unset($entity);
+        $this->assertSame(0, MyCustomEntity::$count);
+    }
+}
+
+class MyCustomForm extends CustomForm
+{
+    public static $count = 0;
+
+    public function __construct(?FormBuilderInterface $builder = null)
+    {
+        parent::__construct($builder);
+
+        ++self::$count;
+    }
+
+    public function __destruct()
+    {
+        --self::$count;
+    }
+
+    protected function configure(FormBuilderInterface $builder): void
+    {
+        $builder->generates(MyCustomEntity::class);
+
+        $builder
+            ->string('foo')
+            ->length(['min' => 3])
+            ->setter()->getter()
+        ;
+
+        $builder
+            ->integer('bar')
+            ->setter()->getter()
+        ;
+
+        $builder->embedded('embedded', function (ChildBuilderInterface $builder) {
+            $builder->generates(MyCustomEntity::class);
+            $builder->string('foo')
+                ->getter()->setter()
+            ;
+        })->setter();
+    }
+}
+
+class MyCustomEntity
+{
+    public static $count = 0;
+
+    public function __construct()
+    {
+        ++self::$count;
+    }
+
+    public function __destruct()
+    {
+        --self::$count;
+    }
+
+    public function __clone()
+    {
+        ++self::$count;
+    }
+
+    /**
+     * @var string
+     */
+    public $foo;
+
+    /**
+     * @var int
+     */
+    public $bar;
+
+    /**
+     * @var MyCustomEntity
+     */
+    public $embedded;
+}

--- a/tests/Leaf/AnyElementTest.php
+++ b/tests/Leaf/AnyElementTest.php
@@ -239,7 +239,7 @@ class AnyElementTest extends TestCase
         $this->assertNull($element->container());
 
         $container = new Child('name', $element);
-        $container->setParent(new Form(new ChildrenCollection()));
+        $container->setParent($form = new Form(new ChildrenCollection()));
 
         $element = $element->setContainer($container);
 

--- a/tests/Leaf/BooleanElementTest.php
+++ b/tests/Leaf/BooleanElementTest.php
@@ -242,7 +242,7 @@ class BooleanElementTest extends TestCase
         $this->assertNull($element->container());
 
         $container = new Child('name', $element);
-        $container->setParent(new Form(new ChildrenCollection()));
+        $container->setParent($form = new Form(new ChildrenCollection()));
 
         $element = $element->setContainer($container);
 

--- a/tests/Leaf/Date/DateTimeChildBuilderTest.php
+++ b/tests/Leaf/Date/DateTimeChildBuilderTest.php
@@ -22,7 +22,7 @@ class DateTimeChildBuilderTest extends TestCase
             ->buildChild()
         ;
 
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->import(['child' => 123]);
 
         $this->assertInstanceOf(\DateTimeImmutable::class, $child->element()->value());

--- a/tests/Leaf/Date/DateTimeElementTest.php
+++ b/tests/Leaf/Date/DateTimeElementTest.php
@@ -347,7 +347,7 @@ class DateTimeElementTest extends TestCase
         $this->assertNull($element->container());
 
         $container = new Child('name', $element);
-        $container->setParent(new Form(new ChildrenCollection()));
+        $container->setParent($form = new Form(new ChildrenCollection()));
 
         $element = $element->setContainer($container);
 

--- a/tests/Leaf/FloatElementTest.php
+++ b/tests/Leaf/FloatElementTest.php
@@ -279,7 +279,7 @@ class FloatElementTest extends TestCase
         $this->assertNull($element->container());
 
         $container = new Child('name', $element);
-        $container->setParent(new Form(new ChildrenCollection()));
+        $container->setParent($form = new Form(new ChildrenCollection()));
 
         $element = $element->setContainer($container);
 

--- a/tests/Leaf/IntegerElementTest.php
+++ b/tests/Leaf/IntegerElementTest.php
@@ -279,7 +279,7 @@ class IntegerElementTest extends TestCase
         $this->assertNull($element->container());
 
         $container = new Child('name', $element);
-        $container->setParent(new Form(new ChildrenCollection()));
+        $container->setParent($form = new Form(new ChildrenCollection()));
 
         $element = $element->setContainer($container);
 

--- a/tests/Leaf/StringElementTest.php
+++ b/tests/Leaf/StringElementTest.php
@@ -274,7 +274,7 @@ class StringElementTest extends TestCase
         $this->assertNull($element->container());
 
         $container = new Child('name', $element);
-        $container->setParent(new Form(new ChildrenCollection()));
+        $container->setParent($form = new Form(new ChildrenCollection()));
 
         $element = $element->setContainer($container);
 

--- a/tests/Phone/PhoneChildBuilderTest.php
+++ b/tests/Phone/PhoneChildBuilderTest.php
@@ -19,7 +19,7 @@ class PhoneChildBuilderTest extends TestCase
         $builder->saveAsString($format)->getter()->setter()->region('FR');
 
         $child = $builder->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->import(['child' => '0142563698']);
 
@@ -38,7 +38,7 @@ class PhoneChildBuilderTest extends TestCase
         $builder->saveAsString()->saveAsString(null)->getter()->setter()->region('FR');
 
         $child = $builder->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
 
         $child->submit(['child' => '0142563698']);
 
@@ -58,25 +58,25 @@ class PhoneChildBuilderTest extends TestCase
         $builder = new PhoneChildBuilder('child', new PhoneElementBuilder());
         $builder->saveAsString()->getter()->setter()->region('FR');
         $child = $builder->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->submit(['child' => '145 5/4']);
         $child->fill($target);
         $this->assertSame(['child' => '145 5/4'], $target);
 
         $child = $builder->formatIfInvalid()->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->submit(['child' => '145 5/4']);
         $child->fill($target);
         $this->assertSame(['child' => '+3314554'], $target);
 
         $child = $builder->formatIfInvalid(false)->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->submit(['child' => '145 5/4']);
         $child->fill($target);
         $this->assertSame(['child' => '145 5/4'], $target);
 
         $child = $builder->formatIfInvalid(true)->buildChild();
-        $child->setParent(new Form(new ChildrenCollection()));
+        $child->setParent($form = new Form(new ChildrenCollection()));
         $child->submit(['child' => '145 5/4']);
         $child->fill($target);
         $this->assertSame(['child' => '+3314554'], $target);

--- a/tests/Phone/PhoneElementBuilderTest.php
+++ b/tests/Phone/PhoneElementBuilderTest.php
@@ -200,7 +200,7 @@ class PhoneElementBuilderTest extends TestCase
         $formBuilder->string('country');
         $form = $formBuilder->buildElement();
 
-        $element = $element->setContainer(new Child('phone', $element));
+        $element = $element->setContainer($container = new Child('phone', $element));
         $element->container()->setParent($form);
 
         $form['country']->element()->import('fr');

--- a/tests/Phone/PhoneElementTest.php
+++ b/tests/Phone/PhoneElementTest.php
@@ -261,7 +261,7 @@ class PhoneElementTest extends TestCase
         $this->assertNull($element->container());
 
         $container = new Child('name', $element);
-        $container->setParent(new Form(new ChildrenCollection()));
+        $container->setParent($form = new Form(new ChildrenCollection()));
 
         $element = $element->setContainer($container);
 

--- a/tests/PropertyAccess/GetterTest.php
+++ b/tests/PropertyAccess/GetterTest.php
@@ -22,7 +22,7 @@ class GetterTest extends TestCase
         $builder->extractor(new Getter());
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $input->import(new GetterTestEntity('my value'));
 
@@ -38,7 +38,7 @@ class GetterTest extends TestCase
         $builder->extractor(new Getter('public'));
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $input->import(new GetterTestEntity('my value'));
 
@@ -58,7 +58,7 @@ class GetterTest extends TestCase
         }));
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $input->import(new GetterTestEntity('my value'));
 
@@ -80,7 +80,7 @@ class GetterTest extends TestCase
         }));
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $input->import(new GetterTestEntity('my value'));
 
@@ -102,7 +102,7 @@ class GetterTest extends TestCase
         }));
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $input->import(new GetterTestEntity('my value'));
 
@@ -122,7 +122,7 @@ class GetterTest extends TestCase
         $builder->extractor(new Getter());
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $input->import(new GetterTestEntity(null, 'my value'));
 
@@ -138,7 +138,7 @@ class GetterTest extends TestCase
         $builder->extractor(new Getter('foo.bar'));
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $entity = new class {
             public $foo;
@@ -165,7 +165,7 @@ class GetterTest extends TestCase
         $builder->extractor(new Getter('0'));
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $input->import(['foo', 'bar']);
 

--- a/tests/PropertyAccess/SetterTest.php
+++ b/tests/PropertyAccess/SetterTest.php
@@ -22,7 +22,7 @@ class SetterTest extends TestCase
         $builder->hydrator(new Setter())->value('my value');
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $entity = new SetterTestEntity();
         $input->fill($entity);
@@ -39,7 +39,7 @@ class SetterTest extends TestCase
         $builder->hydrator(new Setter('public'))->value('my value');
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $entity = new SetterTestEntity();
         $input->fill($entity);
@@ -60,7 +60,7 @@ class SetterTest extends TestCase
         }))->value('my value');
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $entity = new SetterTestEntity();
         $input->fill($entity);
@@ -83,7 +83,7 @@ class SetterTest extends TestCase
         }))->value('my value');
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $entity = new SetterTestEntity();
         $input->fill($entity);
@@ -106,7 +106,7 @@ class SetterTest extends TestCase
         }))->value('my value');
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $entity = new SetterTestEntity();
         $input->fill($entity);
@@ -126,7 +126,7 @@ class SetterTest extends TestCase
         $builder->hydrator(new Setter())->value('my value');
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $entity = new SetterTestEntity();
         $input->fill($entity);
@@ -143,7 +143,7 @@ class SetterTest extends TestCase
         $builder->hydrator(new Setter('foo.bar'));
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $entity = new class {
             public $foo;
@@ -171,7 +171,7 @@ class SetterTest extends TestCase
         $builder->hydrator(new Setter('0'))->value('my value');
 
         $input = $builder->buildChild();
-        $input->setParent(new Form(new ChildrenCollection()));
+        $input->setParent($form = new Form(new ChildrenCollection()));
 
         $out = [];
         $input->fill($out);


### PR DESCRIPTION
Note: will add BC break on BDF 1.8 because of the validator system which wrap the element into a `WeakReference`